### PR TITLE
Add width and height options

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,7 @@
+## 2.6.2
+
+- Add `height` and `width` properties to `FireworksOptions` typescript definition
+
 ## 2.6.1
 
 - Make start idempotent (#16)

--- a/fireworks.d.ts
+++ b/fireworks.d.ts
@@ -26,6 +26,8 @@ declare namespace Fireworks {
     rocketSpawnInterval?: number
     rocketInitialPoint?: number
     cannons?: Point[]
+    width?: number
+    height?: number
   }
 }
 


### PR DESCRIPTION
This PR adds ```width``` and ```height``` options to the ```FireworksOptions``` Typescript definition so Typescript users can make use of those properties in their config.